### PR TITLE
Update DocQuery to emit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ DocQuery {}
 
 > dq.documents
 // [...returns list of all documents sorted newest to oldest]
+
+> dq.on("ready", function() { console.log("fires when documents are finished loading") })
+> dq.on("added", function(fileDetails) { console.log("fires when a document is added") })
+> dq.on("updated", function(fileDetails) { console.log("fires when a document is updated") })
+> dq.on("removed", function(fileDetails) { console.log("fires when a document is removed") })
 ```
 
 ### Command Line

--- a/lib/DocQuery.js
+++ b/lib/DocQuery.js
@@ -2,7 +2,11 @@
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
+var _get = function get(_x2, _x3, _x4) { var _again = true; _function: while (_again) { var object = _x2, property = _x3, receiver = _x4; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x2 = parent; _x3 = property; _x4 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
 var fs = require("fs");
 var tilde = require("tilde-expansion");
@@ -10,7 +14,11 @@ var path = require("path");
 var lunr = require("lunr");
 var chokidar = require("chokidar");
 
-var DocQuery = (function () {
+var _require = require("events");
+
+var EventEmitter = _require.EventEmitter;
+
+var DocQuery = (function (_EventEmitter) {
   function DocQuery(directoryPath) {
     var _this = this;
 
@@ -18,6 +26,7 @@ var DocQuery = (function () {
 
     _classCallCheck(this, DocQuery);
 
+    _get(Object.getPrototypeOf(DocQuery.prototype), "constructor", this).call(this);
     this.options = options || {};
     this.options.extensions = options.extensions || [".md", ".txt"];
     this.options.persistent = options.persistent == false ? false : true;
@@ -59,10 +68,15 @@ var DocQuery = (function () {
     this.watcher.on("unlink", function (filePath) {
       _this.removeDocument(_this._documents[filePath]);
     });
+    this.watcher.on("ready", function () {
+      _this.emit("ready");
+    });
     tilde(directoryPath, function (expandedDirectoryPath) {
       _this.watcher.add(expandedDirectoryPath);
     });
   }
+
+  _inherits(DocQuery, _EventEmitter);
 
   _createClass(DocQuery, [{
     key: "addDocument",
@@ -73,6 +87,7 @@ var DocQuery = (function () {
         title: fileDetails.title,
         body: fileDetails.body
       });
+      this.emit("added", fileDetails);
     }
   }, {
     key: "updateDocument",
@@ -83,6 +98,7 @@ var DocQuery = (function () {
         title: fileDetails.title,
         body: fileDetails.body
       });
+      this.emit("updated", fileDetails);
     }
   }, {
     key: "removeDocument",
@@ -93,6 +109,7 @@ var DocQuery = (function () {
         title: fileDetails.title,
         body: fileDetails.body
       });
+      this.emit("removed", fileDetails);
     }
   }, {
     key: "search",
@@ -134,6 +151,6 @@ var DocQuery = (function () {
   }]);
 
   return DocQuery;
-})();
+})(EventEmitter);
 
 module.exports = DocQuery;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chokidar": "^1.0.1",
     "lunr": "^0.5.9",
     "minimist": "^1.1.1",
-    "tilde-expansion": "0.0.0"
+    "tilde-expansion": "0.0.0",
+    "underscore": "^1.8.3"
   }
 }

--- a/src/docquery.js
+++ b/src/docquery.js
@@ -3,9 +3,11 @@ let tilde = require("tilde-expansion")
 let path = require("path")
 let lunr = require("lunr")
 let chokidar = require("chokidar")
+let {EventEmitter} = require("events")
 
-class DocQuery {
+class DocQuery extends EventEmitter {
   constructor(directoryPath, options={}) {
+    super()
     this.options = options || {}
     this.options.extensions  = options.extensions || [".md", ".txt"]
     this.options.persistent  = options.persistent == false ? false : true
@@ -47,6 +49,9 @@ class DocQuery {
     this.watcher.on("unlink", (filePath)=>{
       this.removeDocument(this._documents[filePath])
     })
+    this.watcher.on("ready", ()=>{
+      this.emit("ready")
+    })
     tilde(directoryPath, (expandedDirectoryPath)=>{
       this.watcher.add(expandedDirectoryPath)
     })
@@ -59,6 +64,7 @@ class DocQuery {
       title: fileDetails.title,
       body: fileDetails.body
     })
+    this.emit("added", fileDetails)
   }
 
   updateDocument(fileDetails) {
@@ -68,6 +74,7 @@ class DocQuery {
       title: fileDetails.title,
       body: fileDetails.body
     })
+    this.emit("updated", fileDetails)
   }
 
   removeDocument(fileDetails) {
@@ -77,6 +84,7 @@ class DocQuery {
       title: fileDetails.title,
       body: fileDetails.body
     })
+    this.emit("removed", fileDetails)
   }
 
   search(query) {


### PR DESCRIPTION
A DocQuery instance now responds to EventEmitter methods (like `on`). The events it emits are:
- `ready`: documents are finished loading
- `added`: a document is added, includes file details
- `updated`: a document is updated, includes file details
- `removed`: a document is removed, includes file details
