### PR TITLE
Update lunr version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "chokidar": "^1.0.1",
-    "lunr": "^0.5.9",
+    "lunr": "^0.6.0",
     "minimist": "^1.1.1",
     "tilde-expansion": "0.0.0",
     "underscore": "^1.8.3"


### PR DESCRIPTION
Lower version is causing nvatom unusable: https://github.com/seongjaelee/nvatom/issues/32
The bug fix is here: https://github.com/olivernn/lunr.js/issues/178
