### PR TITLE
Allows option to pass in searchIndex for loading.

### DIFF
--- a/lib/DocQuery.js
+++ b/lib/DocQuery.js
@@ -32,10 +32,14 @@ var DocQuery = (function (_EventEmitter) {
     this.options.persistent = options.persistent == false ? false : true;
     this.options.includeBody = options.includeBody == false ? false : true;
     this._documents = {};
-    this.searchIndex = lunr(function () {
-      this.field("title", { boost: 10 });
-      this.field("body");
-    });
+    if (this.options.searchIndex) {
+      this.searchIndex = lunr.Index.load(this.options.searchIndex);
+    } else {
+      this.searchIndex = lunr(function () {
+        this.field("title", { boost: 10 });
+        this.field("body");
+      });
+    }
     this.watcher = chokidar.watch(null, {
       depth: this.options.recursive ? undefined : 0,
       persistent: this.options.persistent,

--- a/src/docquery.js
+++ b/src/docquery.js
@@ -13,10 +13,14 @@ class DocQuery extends EventEmitter {
     this.options.persistent  = options.persistent == false ? false : true
     this.options.includeBody = options.includeBody == false ? false : true
     this._documents = {}
-    this.searchIndex = lunr(function() {
-      this.field("title", { boost: 10 })
-      this.field("body")
-    })
+    if (this.options.searchIndex) {
+      this.searchIndex = lunr.Index.load(this.options.searchIndex)
+    } else {
+      this.searchIndex = lunr(function () {
+        this.field("title", { boost: 10 })
+        this.field("body")
+      });
+    }
     this.watcher = chokidar.watch(null, {
       depth: this.options.recursive ? undefined : 0,
       persistent: this.options.persistent,


### PR DESCRIPTION
Allows users to pass in a pre-existing searchIndex. `lunr` supports this via `lunr.Index.load()`.